### PR TITLE
 Redact passwords from prometheus metrics. With configurable replacement string.

### DIFF
--- a/runrestic/restic/runner.py
+++ b/runrestic/restic/runner.py
@@ -29,7 +29,11 @@ class ResticRunner:
 
         self.metrics: Dict[str, Any] = {"errors": 0}
         self.log_metrics = config.get("metrics") and not args.dry_run
-        self.pw_replacement = config.get("metrics",{}).get("prometheus",{}).get("password_replacement", "")
+        self.pw_replacement = (
+            config.get("metrics", {})
+            .get("prometheus", {})
+            .get("password_replacement", "")
+        )
 
         initialize_environment(self.config["environment"])
 
@@ -122,7 +126,9 @@ class ResticRunner:
                 metrics[redact_password(repo, self.pw_replacement)] = {"rc": rc}
                 self.metrics["errors"] += 1
             else:
-                metrics[redact_password(repo, self.pw_replacement)] = parse_backup(process_infos)
+                metrics[redact_password(repo, self.pw_replacement)] = parse_backup(
+                    process_infos
+                )
 
         # backup post_hooks
         if cfg.get("post_hooks"):
@@ -169,7 +175,9 @@ class ResticRunner:
                 metrics[redact_password(repo, self.pw_replacement)] = {"rc": rc}
                 self.metrics["errors"] += 1
             else:
-                metrics[redact_password(repo, self.pw_replacement)] = parse_forget(process_infos)
+                metrics[redact_password(repo, self.pw_replacement)] = parse_forget(
+                    process_infos
+                )
 
     def prune(self) -> None:
         metrics = self.metrics["prune"] = {}
@@ -186,7 +194,9 @@ class ResticRunner:
                 metrics[redact_password(repo, self.pw_replacement)] = {"rc": rc}
                 self.metrics["errors"] += 1
             else:
-                metrics[redact_password(repo, self.pw_replacement)] = parse_prune(process_infos)
+                metrics[redact_password(repo, self.pw_replacement)] = parse_prune(
+                    process_infos
+                )
 
     def check(self) -> None:
         self.metrics["check"] = {}
@@ -243,4 +253,6 @@ class ResticRunner:
                 metrics[redact_password(repo, self.pw_replacement)] = {"rc": rc}
                 self.metrics["errors"] += 1
             else:
-                metrics[redact_password(repo, self.pw_replacement)] = parse_stats(process_infos)
+                metrics[redact_password(repo, self.pw_replacement)] = parse_stats(
+                    process_infos
+                )

--- a/runrestic/restic/runner.py
+++ b/runrestic/restic/runner.py
@@ -12,7 +12,7 @@ from runrestic.restic.output_parsing import (
     parse_prune,
     parse_stats,
 )
-from runrestic.restic.tools import MultiCommand, initialize_environment
+from runrestic.restic.tools import MultiCommand, initialize_environment, redact_password
 
 logger = logging.getLogger(__name__)
 
@@ -118,10 +118,10 @@ class ResticRunner:
             rc = process_infos["output"][-1][0]
             if rc > 0:
                 logger.warning(process_infos)
-                metrics[repo] = {"rc": rc}
+                metrics[redact_password(repo)] = {"rc": rc}
                 self.metrics["errors"] += 1
             else:
-                metrics[repo] = parse_backup(process_infos)
+                metrics[redact_password(repo)] = parse_backup(process_infos)
 
         # backup post_hooks
         if cfg.get("post_hooks"):
@@ -165,10 +165,10 @@ class ResticRunner:
             rc = process_infos["output"][-1][0]
             if rc > 0:
                 logger.warning(process_infos["output"])
-                metrics[repo] = {"rc": rc}
+                metrics[redact_password(repo)] = {"rc": rc}
                 self.metrics["errors"] += 1
             else:
-                metrics[repo] = parse_forget(process_infos)
+                metrics[redact_password(repo)] = parse_forget(process_infos)
 
     def prune(self) -> None:
         metrics = self.metrics["prune"] = {}
@@ -182,10 +182,10 @@ class ResticRunner:
             rc = process_infos["output"][-1][0]
             if rc > 0:
                 logger.warning(process_infos["output"])
-                metrics[repo] = {"rc": rc}
+                metrics[redact_password(repo)] = {"rc": rc}
                 self.metrics["errors"] += 1
             else:
-                metrics[repo] = parse_prune(process_infos)
+                metrics[redact_password(repo)] = parse_prune(process_infos)
 
     def check(self) -> None:
         self.metrics["check"] = {}
@@ -224,7 +224,7 @@ class ResticRunner:
                 metrics["errors"] = 1
             metrics["duration_seconds"] = process_infos["time"]
             metrics["rc"] = rc
-            self.metrics["check"][repo] = metrics
+            self.metrics["check"][redact_password(repo)] = metrics
 
     def stats(self) -> None:
         metrics = self.metrics["stats"] = {}
@@ -239,7 +239,7 @@ class ResticRunner:
             rc = process_infos["output"][-1][0]
             if rc > 0:
                 logger.warning(process_infos["output"])
-                metrics[repo] = {"rc": rc}
+                metrics[redact_password(repo)] = {"rc": rc}
                 self.metrics["errors"] += 1
             else:
-                metrics[repo] = parse_stats(process_infos)
+                metrics[redact_password(repo)] = parse_stats(process_infos)

--- a/runrestic/restic/runner.py
+++ b/runrestic/restic/runner.py
@@ -29,6 +29,7 @@ class ResticRunner:
 
         self.metrics: Dict[str, Any] = {"errors": 0}
         self.log_metrics = config.get("metrics") and not args.dry_run
+        self.pw_replacement = config.get("metrics",{}).get("prometheus",{}).get("password_replacement", "")
 
         initialize_environment(self.config["environment"])
 
@@ -118,10 +119,10 @@ class ResticRunner:
             rc = process_infos["output"][-1][0]
             if rc > 0:
                 logger.warning(process_infos)
-                metrics[redact_password(repo)] = {"rc": rc}
+                metrics[redact_password(repo, self.pw_replacement)] = {"rc": rc}
                 self.metrics["errors"] += 1
             else:
-                metrics[redact_password(repo)] = parse_backup(process_infos)
+                metrics[redact_password(repo, self.pw_replacement)] = parse_backup(process_infos)
 
         # backup post_hooks
         if cfg.get("post_hooks"):
@@ -165,10 +166,10 @@ class ResticRunner:
             rc = process_infos["output"][-1][0]
             if rc > 0:
                 logger.warning(process_infos["output"])
-                metrics[redact_password(repo)] = {"rc": rc}
+                metrics[redact_password(repo, self.pw_replacement)] = {"rc": rc}
                 self.metrics["errors"] += 1
             else:
-                metrics[redact_password(repo)] = parse_forget(process_infos)
+                metrics[redact_password(repo, self.pw_replacement)] = parse_forget(process_infos)
 
     def prune(self) -> None:
         metrics = self.metrics["prune"] = {}
@@ -182,10 +183,10 @@ class ResticRunner:
             rc = process_infos["output"][-1][0]
             if rc > 0:
                 logger.warning(process_infos["output"])
-                metrics[redact_password(repo)] = {"rc": rc}
+                metrics[redact_password(repo, self.pw_replacement)] = {"rc": rc}
                 self.metrics["errors"] += 1
             else:
-                metrics[redact_password(repo)] = parse_prune(process_infos)
+                metrics[redact_password(repo, self.pw_replacement)] = parse_prune(process_infos)
 
     def check(self) -> None:
         self.metrics["check"] = {}
@@ -224,7 +225,7 @@ class ResticRunner:
                 metrics["errors"] = 1
             metrics["duration_seconds"] = process_infos["time"]
             metrics["rc"] = rc
-            self.metrics["check"][redact_password(repo)] = metrics
+            self.metrics["check"][redact_password(repo, self.pw_replacement)] = metrics
 
     def stats(self) -> None:
         metrics = self.metrics["stats"] = {}
@@ -239,7 +240,7 @@ class ResticRunner:
             rc = process_infos["output"][-1][0]
             if rc > 0:
                 logger.warning(process_infos["output"])
-                metrics[redact_password(repo)] = {"rc": rc}
+                metrics[redact_password(repo, self.pw_replacement)] = {"rc": rc}
                 self.metrics["errors"] += 1
             else:
-                metrics[redact_password(repo)] = parse_stats(process_infos)
+                metrics[redact_password(repo, self.pw_replacement)] = parse_stats(process_infos)

--- a/runrestic/restic/tools.py
+++ b/runrestic/restic/tools.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import time
+import re
 from concurrent.futures import Future
 from concurrent.futures.process import ProcessPoolExecutor
 from subprocess import PIPE, Popen, STDOUT
@@ -90,3 +91,8 @@ def initialize_environment(config: Dict[str, Any]) -> None:
         os.environ["XDG_CACHE_HOME"] = "/var/cache"
     elif not (os.environ.get("HOME") or os.environ.get("XDG_CACHE_HOME")):
         os.environ["XDG_CACHE_HOME"] = "/var/cache"
+
+
+def redact_password(repo_str: str) -> str:
+	re_repo = re.compile(r"(^(?:[s]?ftp:|rest:http[s]?:|s3:http[s]?:).*?:)(\S+)(@.*$)")
+	return re_repo.sub(r'\1?????\3', repo_str)

--- a/runrestic/restic/tools.py
+++ b/runrestic/restic/tools.py
@@ -94,5 +94,5 @@ def initialize_environment(config: Dict[str, Any]) -> None:
 
 
 def redact_password(repo_str: str) -> str:
-	re_repo = re.compile(r"(^(?:[s]?ftp:|rest:http[s]?:|s3:http[s]?:).*?:)(\S+)(@.*$)")
-	return re_repo.sub(r'\1?????\3', repo_str)
+    re_repo = re.compile(r"(^(?:[s]?ftp:|rest:http[s]?:|s3:http[s]?:).*?:)(\S+)(@.*$)")
+    return re_repo.sub(r"\1?????\3", repo_str)

--- a/runrestic/restic/tools.py
+++ b/runrestic/restic/tools.py
@@ -93,6 +93,6 @@ def initialize_environment(config: Dict[str, Any]) -> None:
         os.environ["XDG_CACHE_HOME"] = "/var/cache"
 
 
-def redact_password(repo_str: str) -> str:
-    re_repo = re.compile(r"(^(?:[s]?ftp:|rest:http[s]?:|s3:http[s]?:).*?:)(\S+)(@.*$)")
-    return re_repo.sub(r"\1?????\3", repo_str)
+def redact_password(repo_str: str, pw_replacement: str) -> str:
+    re_repo = re.compile(r"(^(?:[s]?ftp:|rest:http[s]?:|s3:http[s]?:).*?):(\S+)(@.*$)")
+    return re_repo.sub(fr"\1:{pw_replacement}\3", repo_str) if pw_replacement else re_repo.sub(r"\1\3", repo_str)

--- a/runrestic/restic/tools.py
+++ b/runrestic/restic/tools.py
@@ -95,4 +95,8 @@ def initialize_environment(config: Dict[str, Any]) -> None:
 
 def redact_password(repo_str: str, pw_replacement: str) -> str:
     re_repo = re.compile(r"(^(?:[s]?ftp:|rest:http[s]?:|s3:http[s]?:).*?):(\S+)(@.*$)")
-    return re_repo.sub(fr"\1:{pw_replacement}\3", repo_str) if pw_replacement else re_repo.sub(r"\1\3", repo_str)
+    return (
+        re_repo.sub(fr"\1:{pw_replacement}\3", repo_str)
+        if pw_replacement
+        else re_repo.sub(r"\1\3", repo_str)
+    )

--- a/runrestic/runrestic/schema.json
+++ b/runrestic/runrestic/schema.json
@@ -110,7 +110,8 @@
           "type": "object",
           "required": ["path"],
           "properties": {
-            "path": {"type": "string"}
+            "path": {"type": "string"},
+            "pw-replacement": {"type": "string"}
           }
         }
       }


### PR DESCRIPTION
Passwords coded into repo URLs will be revealed by prometheus metrics.
This pull request will prevent this and makes the replacement string configurable.

Example:
rest:https://host.teuto.net:VERY_SECRET_PASSWORD@backuphost.teuto.net:8000/host.teuto.net/

Will be changed to this in metrics:
rest:https://host.teuto.net@backuphost.teuto.net:8000/host.teuto.net/

or, when password_replacement = ????? to:
rest:https://host.teuto.net:?????@backuphost.teuto.net:8000/host.teuto.net/