### PR TITLE
removed bytes info from new prune output parse

### DIFF
--- a/runrestic/restic/output_parsing.py
+++ b/runrestic/restic/output_parsing.py
@@ -97,13 +97,13 @@ def parse_prune(process_infos: Dict[str, Any]) -> Dict[str, Any]:
 def parse_new_prune(process_infos: Dict[str, Any]) -> Dict[str, Any]:
     rc, output = process_infos["output"][-1]
 
-    to_repack_blobs, to_repack_bytes = re.findall(
+    to_repack_blobs = re.findall(
         r"to repack:[\s]+([0-9]+) blobs / (-?[0-9.]+ ?[a-zA-Z]*B)", output
     )[0]
-    removed_blobs, removed_bytes = re.findall(
-        r"this removes[\s]+([0-9]+) blobs / (-?[0-9.]+ ?[a-zA-Z]*B)", output
+    removed_blobs = re.findall(
+        r"this removes:[\s]+([0-9]+) blobs / (-?[0-9.]+ ?[a-zA-Z]*B)", output
     )[0]
-    to_delete_blobs, to_delete_bytes = re.findall(
+    to_delete_blobs = re.findall(
         r"to delete:[\s]+([0-9]+) blobs / (-?[0-9.]+ ?[a-zA-Z]*B)", output
     )[0]
     total_prune_blobs, total_prune_bytes = re.findall(
@@ -117,11 +117,8 @@ def parse_new_prune(process_infos: Dict[str, Any]) -> Dict[str, Any]:
     )[0]
     return {
         "to_repack_blobs": to_repack_blobs,
-        "to_repack_bytes": parse_size(to_repack_bytes),
         "removed_blobs": removed_blobs,
-        "removed_bytes": parse_size(removed_bytes),
         "to_delete_blobs": to_delete_blobs,
-        "to_delete_bytes": parse_size(to_delete_bytes),
         "total_prune_blobs": total_prune_blobs,
         "total_prune_bytes": parse_size(total_prune_bytes),
         "remaining_blobs": remaining_blobs,


### PR DESCRIPTION
Hi, I want to use runrestic, so I made the changes to output parse that allow the code to complete, in line with the changed output in the new (0.13) version of restic.
Not having used runrestic before, I am not getting any output produced, even though the 'parse_new_prune' is now functioning as expected.
I have just discovered resticpy, and this suits my needs more than runrestic.  I was going to ask to add args to the runrestic function but I see that resticpy has everything I need.
Here are the changes to output_parser.py though.