### PR TITLE
output_parsing: fix compat issue with restic 0.14

### DIFF
--- a/runrestic/restic/output_parsing.py
+++ b/runrestic/restic/output_parsing.py
@@ -17,7 +17,7 @@ def parse_backup(process_infos: Dict[str, Any]) -> Dict[str, Any]:
         r"Dirs:\s+([0-9]+) new,\s+([0-9]+) changed,\s+([0-9]+) unmodified", output
     )[0]
     added_to_the_repo = re.findall(
-        r"Added to the repo:\s+(-?[0-9.]+ [a-zA-Z]*B)", output
+        r"Added to the repo(?:sitory)?:\s+(-?[0-9.]+ [a-zA-Z]*B)", output
     )[0]
     processed_files, processed_size, processed_time = re.findall(
         r"processed ([0-9]+) files,\s+(-?[0-9.]+ [a-zA-Z]*B) in ([0-9]+:+[0-9]+)",


### PR DESCRIPTION
Parsing the output of restic 0.14.0 fails currently since restic now uses `repository:` instead of `repo:`:

```
Sep 10 17:29:14 machine runrestic[242808]: [restic] using parent snapshot 6b9fc566
Sep 10 17:30:04 machine runrestic[242808]: [restic] Files:          44 new,    72 changed, 739318 unmodified
Sep 10 17:30:04 machine runrestic[242808]: [restic] Dirs:            0 new,    77 changed, 100262 unmodified
Sep 10 17:30:04 machine runrestic[242808]: [restic] Added to the repository: 24.739 MiB (24.751 MiB stored)
Sep 10 17:30:04 machine runrestic[242808]: [restic] processed 739434 files, 43.510 GiB in 0:51
Sep 10 17:30:04 machine runrestic[242808]: [restic] snapshot 8e61387b saved
```