### PR TITLE
Small code improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ sudo chmod +x /etc/cron.d/runrestic
   - Drop support for Python 3.8 (EOL 2024-10-07) and 3.9 (EOL 2025-10)
   - Add and update docstrings
   - Add and update type hints
+  - Minor code improvements and test coverage
 - v0.5.30
   - Fix metric setting in restic runner for "check"
   - Support Python 3.13

--- a/runrestic/restic/shell.py
+++ b/runrestic/restic/shell.py
@@ -44,8 +44,13 @@ def restic_shell(configs: list[dict[str, Any]]) -> None:
                 all_repos.append((config, repo))
                 i += 1
 
-        selection = int(input(f"Choose a repo [0-{i - 1}]: "))
-        selected_config, selected_repo = all_repos[selection]
+        try:
+            selection = int(input(f"Choose a repo [0-{i - 1}]: "))
+            selected_config, selected_repo = all_repos[selection]
+        except (ValueError, IndexError):
+            raise ValueError(
+                "Invalid selection. Please choose a valid repository index."
+            )  # noqa: B904, TRY003
 
     env: dict[str, str] = selected_config["environment"]
     env.update({"RESTIC_REPOSITORY": selected_repo})

--- a/tests/restic/test_installer.py
+++ b/tests/restic/test_installer.py
@@ -1,5 +1,5 @@
 from unittest import TestCase
-from unittest.mock import patch, mock_open
+from unittest.mock import patch
 
 from runrestic.restic import installer
 
@@ -33,20 +33,19 @@ class TestInstaller(TestCase):
                     "runrestic.restic.installer.bz2.decompress",
                     return_value=b"dummy_program",
                 ),
-                patch("runrestic.restic.installer.os.chmod") as mock_chmod,
-                patch("builtins.open", new_callable=mock_open) as mock_file_open,
+                patch("runrestic.restic.installer.Path.write_bytes"),
+                patch("runrestic.restic.installer.Path.chmod"),
             ):
                 installer.download_restic()
                 mock_get.assert_any_call(
                     "https://api.github.com/repos/restic/restic/releases/latest",
+                    timeout=10,
                 )
                 mock_get.assert_called_with(
                     "https://example.com/restic_linux_amd64.bz2",
                     allow_redirects=True,
+                    timeout=60,
                 )
-                # Assert open() was called with the right path and mode
-                mock_file_open.assert_called_once_with("/usr/local/bin/restic", "wb")
-                mock_chmod.assert_called_once_with("/usr/local/bin/restic", 0o755)
 
     def test_download_restic_permission_error(self):
         # Mock the requests.get method to simulate a successful response
@@ -56,22 +55,21 @@ class TestInstaller(TestCase):
                 "runrestic.restic.installer.bz2.decompress",
                 return_value=b"dummy_program",
             ),
+            patch("runrestic.restic.installer.Path.chmod"),
         ):
             mock_get.return_value.status_code = 200
             mock_get.return_value.content = b'{"assets": [{"name": "restic_linux_amd64.bz2", "browser_download_url": "https://example.com/restic_linux_amd64.bz2"}]}'
             with (
                 patch("builtins.print") as mock_print,
-                patch("builtins.open", new_callable=mock_open) as mock_file_open,
+                patch(
+                    "runrestic.restic.installer.Path.write_bytes",
+                    side_effect=PermissionError,
+                ) as mock_write,
                 patch("builtins.input", return_value=""),
             ):
-                file_handle = mock_file_open()
-                file_handle.write.side_effect = [
-                    PermissionError,
-                    None,
-                ]
                 installer.download_restic()
                 mock_print.assert_any_call("\nTry re-running this as root.")
-                file_handle.write.assert_called_once()
+                mock_write.assert_called_once()
 
     def test_download_restic_permission_error_alt(self):
         # Mock the requests.get method to simulate a successful response
@@ -81,58 +79,64 @@ class TestInstaller(TestCase):
                 "runrestic.restic.installer.bz2.decompress",
                 return_value=b"dummy_program",
             ),
+            patch("runrestic.restic.installer.Path.chmod"),
         ):
             mock_get.return_value.status_code = 200
             mock_get.return_value.content = b'{"assets": [{"name": "restic_linux_amd64.bz2", "browser_download_url": "https://example.com/restic_linux_amd64.bz2"}]}'
             with (
                 patch("builtins.print") as mock_print,
-                patch("builtins.open", new_callable=mock_open) as mock_file_open,
                 patch(
-                    "runrestic.restic.installer.os.chmod",
-                ) as mock_chmod,
+                    "runrestic.restic.installer.Path.write_bytes",
+                    side_effect=[PermissionError, None],
+                ) as mock_write,
                 patch("builtins.input", return_value="alt_path"),
             ):
-                file_handle = mock_file_open()
-                file_handle.write.side_effect = [
-                    PermissionError,
-                    None,
-                ]
                 installer.download_restic()
                 mock_print.assert_any_call("\nTry re-running this as root.")
-                self.assertEqual(file_handle.write.call_count, 2)
-                mock_chmod.assert_called_once_with("alt_path", 0o755)
+                self.assertEqual(mock_write.call_count, 2)
 
     def test_download_restic_no_assets(self):
         # Mock the requests.get method to simulate a successful response
         with patch("runrestic.restic.installer.requests.get") as mock_get:
             mock_get.return_value.status_code = 200
             mock_get.return_value.content = b'{"dummy": 42}'
-            self.assertRaises(
-                KeyError,
-                installer.download_restic,
-            )
+            with patch("builtins.print") as mock_print:
+                installer.download_restic()
+                mock_print.assert_called_with(
+                    "Error: Could not find a suitable Restic binary to download."
+                )
+                mock_get.assert_called_with(
+                    "https://api.github.com/repos/restic/restic/releases/latest",
+                    timeout=10,
+                )
 
     def test_download_restic_assets_no_match(self):
         # Mock the requests.get method to simulate a successful response
         with patch("runrestic.restic.installer.requests.get") as mock_get:
             mock_get.return_value.status_code = 200
             mock_get.return_value.content = b'{"assets": [{"name": "restic_fake_os.bz2", "browser_download_url": "https://example.com/restic_fake_os.bz2"}]}'
-            mock_get.side_effect = [
-                # Simulate successful response for fetching release
-                type(
-                    "Response",
-                    (object,),
-                    {
-                        "status_code": 200,
-                        "content": b'{"assets": [{"name": "restic_fake_os.bz2", "browser_download_url": "https://example.com/restic_fake_os.bz2"}]}',
-                        "raise_for_status": lambda x: True,
-                    },
-                )(),
-                # Simulate exception during program download
-                installer.requests.exceptions.MissingSchema("Invalid URL ''"),
-            ]
-            self.assertRaises(
-                installer.requests.exceptions.MissingSchema, installer.download_restic
+            with patch("builtins.print") as mock_print:
+                installer.download_restic()
+                mock_print.assert_called_with(
+                    "Error: Could not find a suitable Restic binary to download."
+                )
+                mock_get.assert_called_with(
+                    "https://api.github.com/repos/restic/restic/releases/latest",
+                    timeout=10,
+                )
+
+    def test_download_restic_timeout_fetch_release(self):
+        # Mock the requests.get method to simulate a timeout
+        with (
+            patch(
+                "runrestic.restic.installer.requests.get",
+                side_effect=installer.requests.exceptions.Timeout,
+            ),
+            patch("builtins.print") as mock_print,
+        ):
+            installer.download_restic()
+            mock_print.assert_called_with(
+                "Error: Unable to fetch the latest Restic release due to a timeout."
             )
 
     def test_download_restic_request_exception_fetch_release(self):
@@ -144,10 +148,38 @@ class TestInstaller(TestCase):
                     "Request failed"
                 ),
             ),
+            patch("builtins.print") as mock_print,
         ):
-            self.assertRaises(
-                installer.requests.exceptions.RequestException,
-                installer.download_restic,
+            installer.download_restic()
+            mock_print.assert_called_with(
+                "Error: Unable to fetch the latest Restic release: Request failed"
+            )
+
+    def test_download_restic_timeout_download_program(self):
+        # Mock the requests.get method to simulate a timeout during program download
+        with (
+            patch(
+                "runrestic.restic.installer.requests.get",
+                side_effect=[
+                    # Simulate successful response for fetching release
+                    type(
+                        "Response",
+                        (object,),
+                        {
+                            "status_code": 200,
+                            "content": b'{"assets": [{"name": "restic_linux_amd64.bz2", "browser_download_url": "https://example.com/restic_linux_amd64.bz2"}]}',
+                            "raise_for_status": lambda x: True,
+                        },
+                    )(),
+                    # Simulate timeout during program download
+                    installer.requests.exceptions.Timeout,
+                ],
+            ),
+            patch("builtins.print") as mock_print,
+        ):
+            installer.download_restic()
+            mock_print.assert_called_with(
+                "Error: Unable to download the Restic binary due to a timeout."
             )
 
     def test_download_restic_request_exception_download_program(self):
@@ -169,10 +201,10 @@ class TestInstaller(TestCase):
                     # Simulate exception during program download
                     installer.requests.exceptions.RequestException("Request failed"),
                 ],
-            ) as mock_get,
+            ),
+            patch("builtins.print") as mock_print,
         ):
-            self.assertRaises(
-                installer.requests.exceptions.RequestException,
-                installer.download_restic,
+            installer.download_restic()
+            mock_print.assert_called_with(
+                "Error: Unable to download the Restic binary: Request failed"
             )
-            self.assertEqual(mock_get.call_count, 2)

--- a/tests/restic/test_shell.py
+++ b/tests/restic/test_shell.py
@@ -12,6 +12,9 @@ class TestResticShell(TestCase):
             # Set a default shell for the test environment
             os.environ["SHELL"] = "/bin/bash"
 
+    # def tearDown(self) -> None:
+    #     pass
+
     @patch("runrestic.restic.shell.logger")
     @patch("runrestic.restic.shell.sys.exit")
     def test_restic_shell_single_repo(self, mock_sys_exit, mock_logger):
@@ -87,7 +90,7 @@ class TestResticShell(TestCase):
         with self.assertRaises(ValueError) as context:
             shell.restic_shell(configs)
 
-        self.assertEqual(
-            str(context.exception),
-            "invalid literal for int() with base 10: 'X'",
+        self.assertTrue(
+            str(context.exception)
+            == "Invalid selection. Please choose a valid repository index."
         )

--- a/tests/restic/test_tools_subprocess.py
+++ b/tests/restic/test_tools_subprocess.py
@@ -12,10 +12,8 @@ from runrestic.restic import tools
 
 def test_log_messages_no_output():
     """Test log messages with no output"""
-    # Create a fake process object
-    fake_proc = type("FakeProc", (), {})()
-    fake_proc.stdout = StringIO("    ")
-    assert tools.log_messages(fake_proc, "test_cmd") == ""
+    assert tools.log_messages(None, "test_cmd") == ""
+    assert tools.log_messages(StringIO("    "), "test_cmd") == ""
 
 
 def test_restic_logs(caplog, fp, monkeypatch):  # pylint: disable=invalid-name

--- a/tests/runrestic/test_runrestic_tools.py
+++ b/tests/runrestic/test_runrestic_tools.py
@@ -114,3 +114,16 @@ def test_parse_line_no_match_three():
         OUTPUT,
         ("-1", "-1", "-1"),
     ) == ("-1", "-1", "-1")
+
+
+def test_parse_line_type_mismatch():
+    # Test if the parsed type matches the type provided in the default
+    # In this test, the parsed type is a tuple, while the default is a string
+    assert (
+        parse_line(
+            r"Three counters: value 1: ([\d\.]+), value 2: (\d+), value 3: ([\d\.]+ [kMG]?B)",
+            OUTPUT,
+            "-1",
+        )
+        == "-1"
+    )


### PR DESCRIPTION
1. improve test coverage
    - parse_line type mismatch
2. update log_messages 
   - Change "message" parameter type to "IO[str]" instead of "process" object in order to simplify the interface
3. add error handling for reop selection in shell function
4. update installer.py
   - timeouts and exception handling
   - use pathlib instead of of calls

This is one more step for #84