### PR TITLE
Add option to backup and prune for tags

### DIFF
--- a/runrestic/restic/runner.py
+++ b/runrestic/restic/runner.py
@@ -154,6 +154,8 @@ class ResticRunner:
             extra_args += ["--exclude-file", exclude_file]
         for exclude_if_present in cfg.get("exclude_if_present", []):
             extra_args += ["--exclude-if-present", exclude_if_present]
+        for tag in cfg.get("tags", []):
+            extra_args += ["--tag", tag]
 
         commands = [
             [
@@ -233,6 +235,9 @@ class ResticRunner:
                 extra_args += [f"--{key}", str(value)]
             if key == "group-by":
                 extra_args += ["--group-by", value]
+            if key == "tags":
+                for tag in value:
+                    extra_args += ["--tag", tag]
 
         direct_abort_reasons = [
             "Fatal: unable to open config file",

--- a/runrestic/runrestic/schema.json
+++ b/runrestic/runrestic/schema.json
@@ -66,6 +66,7 @@
         "exclude_patterns": {"type": "array", "items": {"type": "string"}},
         "exclude_files": {"type": "array", "items": {"type": "string"}},
         "exclude_if_present": {"type": "array", "items": {"type": "string"}},
+        "tags": {"type": "array", "items": {"type": "string"}},
         "pre_hooks": {"type": "array", "items": {"type": "string"}},
         "post_hooks": {"type": "array", "items": {"type": "string"}},
         "continue_on_pre_hooks_error": {"type": "boolean", "default": false}
@@ -93,7 +94,8 @@
         "keep-yearly": {"type": "integer"},
         "keep-within": {"type": "string"},
         "keep-tag": {"type": "string"},
-        "group-by": {"type": "string"}
+        "group-by": {"type": "string"},
+        "tags": {"type": "array", "items": {"type": "string"}}
       }
     },
 


### PR DESCRIPTION
This adds the options for both backup and prune to allow specifying tags. For backup it adds the specified tags to the backup snapshot. For prune it will ensure only snapshots with the specified tags are forgotten.

Tested by adding unit tests and then:
```
poetry run pytest -k test_runner
```

Fixes #93.